### PR TITLE
Fixed duplicate namespace definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,5 @@
         "psr-4": {
             "Elgentos\\LargeConfigProducts\\": ""
         }
-    },
-    "extra": {
-        "map": [
-            [
-                "*",
-                "Elgentos/LargeConfigProducts"
-            ]
-        ]
     }
 }


### PR DESCRIPTION
Since autoload is already defined, the namespace will be available from the vendor folder.
The map folder will also copy everything to app/code, causing the module to be loaded twice