### PR TITLE
inject Prewarmer as Proxy to delay instantion

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -9,6 +9,12 @@
         </arguments>
     </type>
 
+    <type name="\Elgentos\LargeConfigProducts\Console\Command\PrewarmerCommand">
+        <arguments>
+            <argument name="prewarmer" xsi:type="object">Elgentos\LargeConfigProducts\Model\Prewarmer\Proxy</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\ConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider">
         <plugin sortOrder="1" name="elgentosLargeConfigProductsLowestPriceOptionsProvider"
                 type="Elgentos\LargeConfigProducts\Plugin\Pricing\Price\LowestPriceOptionsProviderPlugin"/>


### PR DESCRIPTION
this pull request fixes an issue when running setup:install with the module being already installed via composer.

To reproduce, include this module via composer, run composer install, remove the env.php, run bin/magento setup:install.
The Installation will fail at the very beginning of the database schema installation while creating an instance of the ``\Magento\Framework\Console\CommandListInterface`` where all Commands will get instanciated.