### PR TITLE
Add env.php configuration and introduce Credit_Client Factory

### DIFF
--- a/Cache/CredisClientFactory.php
+++ b/Cache/CredisClientFactory.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace Elgentos\LargeConfigProducts\Cache;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\DeploymentConfig;
+
+class CredisClientFactory
+{
+    /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    public function __construct(DeploymentConfig $deploymentConfig, ScopeConfigInterface $scopeConfig)
+    {
+        $this->deploymentConfig = $deploymentConfig;
+        $this->scopeConfig      = $scopeConfig;
+    }
+
+    public function create(): \Credis_Client
+    {
+        $cacheSetting = $this->deploymentConfig->get('cache');
+
+        $timeout    = null;
+        $persistent = '';
+        if (isset($cacheSetting['frontend']['elgentos_largeconfigproducts']['backend_options'])) {
+            $backendOptions = $cacheSetting['frontend']['elgentos_largeconfigproducts']['backend_options'];
+
+            $server   = $backendOptions['server'];
+            $database = $backendOptions['database'];
+            $port     = $backendOptions['port'];
+
+        } else {
+            $server = $this->scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_host') ?? 'localhost';
+
+            $port     = $this->scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_port') ?? 6379;
+            $database = $this->scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_db_index') ?? 4;
+        }
+
+        return new \Credis_Client($server, $port, $timeout, $persistent, $database);
+    }
+}

--- a/Model/Prewarmer.php
+++ b/Model/Prewarmer.php
@@ -2,12 +2,11 @@
 
 namespace Elgentos\LargeConfigProducts\Model;
 
-use Credis_Client;
+use Elgentos\LargeConfigProducts\Cache\CredisClientFactory;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\ConfigurableProduct\Block\Product\View\Type\Configurable as ProductTypeConfigurable;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Area;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Element\BlockFactory;
 use Magento\Store\Model\App\Emulation;
@@ -26,10 +25,6 @@ class Prewarmer {
      */
     private $emulation;
     /**
-     * @var ScopeConfigInterface
-     */
-    private $scopeConfig;
-    /**
      * @var Registry
      */
     private $coreRegistry;
@@ -42,37 +37,33 @@ class Prewarmer {
 
     /**
      * PrewarmerCommand constructor.
+     *
      * @param ProductRepositoryInterface $productRepository
      * @param StoreManagerInterface $storeManager
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param Emulation $emulation
+     * @param CredisClientFactory $credisClientFactory
      * @param Registry $coreRegistry
      * @param BlockFactory $blockFactory
-     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
         ProductRepositoryInterface $productRepository,
         StoreManagerInterface $storeManager,
         SearchCriteriaBuilder $searchCriteriaBuilder,
         Emulation $emulation,
+        CredisClientFactory $credisClientFactory,
         Registry $coreRegistry,
-        BlockFactory $blockFactory,
-        ScopeConfigInterface $scopeConfig
+        BlockFactory $blockFactory
     ) {
-        $this->productRepository = $productRepository;
-        $this->storeManager = $storeManager;
+        $this->productRepository     = $productRepository;
+        $this->storeManager          = $storeManager;
+        $this->productRepository     = $productRepository;
+        $this->credis                = $credisClientFactory->create();
+        $this->storeManager          = $storeManager;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
-        $this->emulation = $emulation;
-        $this->coreRegistry = $coreRegistry;
-        $this->blockFactory = $blockFactory;
-
-        $this->credis = new Credis_Client(
-            $scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_host') ?? 'localhost',
-            $scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_port') ?? 6379,
-            null,
-            '',
-            $scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_db_index') ?? 4
-        );
+        $this->emulation             = $emulation;
+        $this->coreRegistry          = $coreRegistry;
+        $this->blockFactory          = $blockFactory;
     }
 
     public function prewarm($productIdsToWarm, $storeCodesToWarm, $force)

--- a/Plugin/Model/AttributeOptionProviderPlugin.php
+++ b/Plugin/Model/AttributeOptionProviderPlugin.php
@@ -5,33 +5,37 @@
  * Date: 21-2-18
  * Time: 13:53
  */
+
 namespace Elgentos\LargeConfigProducts\Plugin\Model;
+
+use Elgentos\LargeConfigProducts\Cache\CredisClientFactory;
 use Elgentos\LargeConfigProducts\Model\Prewarmer;
-use Magento\Catalog\Model\ProductFactory;
-use Magento\Framework\App\DeploymentConfig;
 use Magento\Store\Model\StoreManagerInterface;
-use Credis_Client;
 class AttributeOptionProviderPlugin
 {
+    /** @var StoreManagerInterface */
     protected $storeManager;
+
+    /** @var \Credis_Client|null */
     protected $credis;
     /**
      * AttributeOptionProviderPlugin constructor.
+     *
      * @param StoreManagerInterface $storeManager
+     * @param CredisClientFactory $credisClientFactory
      */
     public function __construct(
         StoreManagerInterface $storeManager,
-        DeploymentConfig $deploymentConfig
+        CredisClientFactory $credisClientFactory
     ) {
-        $cacheSetting = $deploymentConfig->get('cache');
-        if (isset($cacheSetting['frontend']['default']['backend_options']['server'])) {
-            $this->credis = new Credis_Client($cacheSetting['frontend']['default']['backend_options']['server']);
-            $this->credis->select(4);
-        }
+        $this->credis       = $credisClientFactory->create();
         $this->storeManager = $storeManager;
     }
-    public function beforeGetAttributeOptions(\Magento\ConfigurableProduct\Model\AttributeOptionProvider $subject, \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $superAttribute, $productId)
-    {
+    public function beforeGetAttributeOptions(
+        \Magento\ConfigurableProduct\Model\AttributeOptionProvider $subject,
+        \Magento\Eav\Model\Entity\Attribute\AbstractAttribute $superAttribute,
+        $productId
+    ) {
         /**
          * The currentStoreId that is being set in the emulation in PrewarmerCommand is somehow lost in the call
          * stack. This plugin uses the store ID found in the Redis DB to re-set the current store so the translated

--- a/Pricing/Price/LowestPriceOptionsProvider.php
+++ b/Pricing/Price/LowestPriceOptionsProvider.php
@@ -8,14 +8,15 @@
 
 namespace Elgentos\LargeConfigProducts\Pricing\Price;
 
-use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Model\ResourceModel\Product\LinkedProductSelectBuilderInterface;
-use Magento\Framework\App\ResourceConnection;
-use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Elgentos\LargeConfigProducts\Model\Prewarmer;
-use Magento\Store\Model\StoreManagerInterface;
 use Credis_Client;
+use Elgentos\LargeConfigProducts\Cache\CredisClientFactory;
+use Elgentos\LargeConfigProducts\Model\Prewarmer;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Catalog\Model\ResourceModel\Product\LinkedProductSelectBuilderInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\StoreManagerInterface;
 
 class LowestPriceOptionsProvider extends \Magento\ConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider
 {
@@ -28,6 +29,7 @@ class LowestPriceOptionsProvider extends \Magento\ConfigurableProduct\Pricing\Pr
      * @var Credis_Client
      */
     protected $credis;
+
     /**
      * @var ResourceConnection
      */
@@ -62,22 +64,14 @@ class LowestPriceOptionsProvider extends \Magento\ConfigurableProduct\Pricing\Pr
         LinkedProductSelectBuilderInterface $linkedProductSelectBuilder,
         CollectionFactory $collectionFactory,
         StoreManagerInterface $storeManager,
-        ScopeConfigInterface $scopeConfig
+        CredisClientFactory $credisClientFactory
     ) {
-        $this->resource = $resourceConnection;
+        $this->resource                   = $resourceConnection;
         $this->linkedProductSelectBuilder = $linkedProductSelectBuilder;
-        $this->collectionFactory = $collectionFactory;
-
-        $this->credis = new Credis_Client(
-            $scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_host') ?? 'localhost',
-            $scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_port') ?? 6379,
-            null,
-            '',
-            $scopeConfig->getValue('elgentos_largeconfigproducts/prewarm/redis_db_index') ?? 4
-        );
-        $this->storeManager = $storeManager;
+        $this->collectionFactory          = $collectionFactory;
+        $this->credis                     = $credisClientFactory->create();
+        $this->storeManager               = $storeManager;
     }
-
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
This pull request will 

- add env.php configuration for elgentos_largeconfigproducts
- use env.php configuration to create the Credis_Client
- fallback to the Settings stored in store config (core_config_data)
- refactor instantiation of Credis_Client to custom Factory

This way it is possible to have a custom configuration in you env.php, looking something like this:

```
  'cache' =>
  array (
    'frontend' =>
    array (
      'elgentos_largeconfigproducts' => [
        'backend' => 'Cm_Cache_Backend_Redis',
        'backend_options' => [
            'server' => '__REDIS_HOST__',
            'port' => '__REDIS_PORT__',
            'password' => '__REDIS_PASSWORD__',
            'persistent' => '',
            'database' => '__REDIS_DATABASE__',
        ]
      ],
```

The recently introduced way using the store-configuration in core_config_data will be used as a fallback mechanism to preserve backwards compatibility.