### PR TITLE
add jsonSwatchImageSizeConfig to fix rendering of swatch-images

### DIFF
--- a/view/frontend/templates/product/view/renderer.phtml
+++ b/view/frontend/templates/product/view/renderer.phtml
@@ -17,8 +17,8 @@
                 "jsonConfig": null<? /* @escapeNotVerified */ //echo $swatchOptions = $block->getJsonConfig() ?>,
                 "jsonSwatchConfig": <?php /* @noEscape */ echo $block->getJsonSwatchConfig(); ?>,
                 "mediaCallback": "<?= /* @escapeNotVerified */ $block->getMediaCallback() ?>",
-                "gallerySwitchStrategy": "<?php /* @escapeNotVerified */ echo $block->getVar('gallery_switch_strategy',
-        'Magento_ConfigurableProduct') ?: 'replace'; ?>"
+                "gallerySwitchStrategy": "<?php /* @escapeNotVerified */ echo $block->getVar('gallery_switch_strategy','Magento_ConfigurableProduct') ?: 'replace'; ?>",
+                "jsonSwatchImageSizeConfig": <?php /* @noEscape */ echo $block->getJsonSwatchSizeConfig() ?>
             },
             "Magento_Swatches/js/configurable-customer-data": {
                     "swatchOptions": null<?php /* @noEscape */ //echo $swatchOptions ?>


### PR DESCRIPTION
This pull request addresses a problem described in this issue https://github.com/elgentos/LargeConfigProducts/issues/31

Custom Swatch Images will now be rendered again.